### PR TITLE
Fix broadcast invalid message

### DIFF
--- a/webserver/public/lib/js/app.js
+++ b/webserver/public/lib/js/app.js
@@ -2265,7 +2265,7 @@
 						return API.chat.log('<br>You do not have permission to perform this command', 'Insufficient Permissions');
 					}
 					if (arr.length < 1){
-						return API.chat.log('<br>Try /broadcst message', 'Broadcasts a message to the room');
+						return API.chat.log('<br>Try /broadcast message', 'Broadcasts a message to the room');
 					}
 					MP.sendBroadcast(arr.join(' '));
 				},


### PR DESCRIPTION
My editor had problems with the indentation of this repo and wanted to only do good and fix it. My apologies for #16.

This pull request actually does what I was trying to do correctly; change `broadcst` to `broadcast`.
