### PR TITLE
Fix Song List Overflow

### DIFF
--- a/webserver/public/lib/css/menus.css
+++ b/webserver/public/lib/css/menus.css
@@ -231,7 +231,7 @@ div.minicolors{
 .lib-sng .text, .yt-sng .text, .hist-sng .text {
 	margin: 0 10px;
 	float: left;
-	width: calc(100% - 252px);
+	width: calc(100% - 272px);
 	overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
This method worked in my browser and it worked when I resized to smaller and normal use sizes as well as as using dev tools from Chrome to test it in terms of responsiveness.  I simply changed the number inside of the calc method in menu.css to account for the possibly wider songs or out of date row width.
